### PR TITLE
Bug 1218197 - Upgrade thermanager for Yukon devices

### DIFF
--- a/rootdir/system/etc/thermanager.xml
+++ b/rootdir/system/etc/thermanager.xml
@@ -1,15 +1,34 @@
 <thermanager>
 	<resources>
 		<!-- thermal zones -->
-		<resource name="zone0" type="tz">/sys/class/thermal/thermal_zone0</resource>
-		<resource name="zone1" type="tz">/sys/class/thermal/thermal_zone1</resource>
-		<resource name="zone2" type="tz">/sys/class/thermal/thermal_zone2</resource>
-		<resource name="zone3" type="tz">/sys/class/thermal/thermal_zone3</resource>
-		<resource name="zone4" type="tz">/sys/class/thermal/thermal_zone4</resource>
-		<resource name="zone5" type="tz">/sys/class/thermal/thermal_zone5</resource>
-		<resource name="zone6" type="tz">/sys/class/thermal/thermal_zone6</resource>
-		<resource name="zone7" type="tz">/sys/class/thermal/thermal_zone7</resource>
-		<resource name="zone8" type="tz">/sys/class/thermal/thermal_zone8</resource>
+		<resource name="tsens_tz_sensor0" type="tz">/sys/class/thermal/thermal_zone0</resource> <!-- cpu0 -->
+		<resource name="tsens_tz_sensor1" type="tz">/sys/class/thermal/thermal_zone1</resource> <!-- cpu1 -->
+		<resource name="tsens_tz_sensor2" type="tz">/sys/class/thermal/thermal_zone2</resource> <!-- gpu0 -->
+		<resource name="tsens_tz_sensor3" type="tz">/sys/class/thermal/thermal_zone3</resource> <!-- gpu1 -->
+		<resource name="tsens_tz_sensor4" type="tz">/sys/class/thermal/thermal_zone4</resource> <!-- cpu2 -->
+		<resource name="tsens_tz_sensor5" type="tz">/sys/class/thermal/thermal_zone5</resource> <!-- cpu3 -->
+
+		<resource name="pm8226_tz" type="tz">/sys/class/thermal/thermal_zone6</resource>
+		<resource name="pa_therm0" type="tz">/sys/class/thermal/thermal_zone7</resource>
+		<resource name="pa_therm1" type="tz">/sys/class/thermal/thermal_zone8</resource>
+		<resource name="battery" type="tz">/sys/class/thermal/thermal_zone9</resource>
+
+		<!--<resource name="temp-core" type="union">
+			<resource name="pa_therm0" />
+			<resource name="pa_therm1" />
+		</resource>-->
+
+		<resource name="temp-cortex-a7" type="union">
+			<resource name="tsens_tz_sensor0" />
+			<resource name="tsens_tz_sensor1" />
+			<resource name="tsens_tz_sensor4" />
+			<resource name="tsens_tz_sensor5" />
+		</resource>
+
+		<resource name="temp-adreno-305" type="union">
+			<resource name="tsens_tz_sensor2" />
+			<resource name="tsens_tz_sensor3" />
+		</resource>
 
 		<!-- generic cpufreq -->
 		<resource name="cpu0" type="sysfs">/sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq</resource>
@@ -17,7 +36,7 @@
 		<resource name="cpu2" type="sysfs">/sys/devices/system/cpu/cpu2/cpufreq/scaling_max_freq</resource>
 		<resource name="cpu3" type="sysfs">/sys/devices/system/cpu/cpu3/cpufreq/scaling_max_freq</resource>
 
-		<resource name="cpu" type="union">
+		<resource name="cortex-a7" type="union">
 			<resource name="cpu0" />
 			<resource name="cpu1" />
 			<resource name="cpu2" />
@@ -27,30 +46,10 @@
 		<!-- device-specific -->
 		<resource name="backlight" type="sysfs">/sys/class/leds/lcd-backlight/max_brightness</resource>
 
-		<resource name="temp-emmc" type="msm-adc">/sys/devices/00-vadc-3100/die_temp</resource>
-		<resource name="temp-batt" type="msm-adc">/sys/devices/00-vadc-3100/batt_therm</resource>
 		<resource name="kgsl-3d0" type="sysfs">/sys/class/kgsl/kgsl-3d0/max_gpuclk</resource>
-		<!--<resource name="dc" type="sysfs">/sys/class/power_supply/qpnp-dc/current_max</resource>-->
 		<resource name="usb" type="sysfs">/sys/class/power_supply/usb/current_max</resource>
-		<resource name="charger" type="sysfs">/sys/class/power_supply/battery/system_temp_level</resource>
-		<resource name="charge_en" type="sysfs">/sys/class/power_supply/battery/charging_enabled</resource>
-
-		<!--<resource name="temp-core" type="union">
-			<resource name="zone7" />
-			<resource name="zone8" />
-		</resource>-->
-
-		<resource name="temp-gpu" type="union">
-			<resource name="zone2" />
-			<resource name="zone3" />
-		</resource>
-
-		<resource name="temp-cpu" type="union">
-			<resource name="zone0" />
-			<resource name="zone1" />
-			<resource name="zone4" />
-			<resource name="zone5" />
-		</resource>
+		<resource name="charge_speed" type="sysfs">/sys/class/power_supply/battery/system_temp_level</resource>
+		<resource name="charging_enabled" type="sysfs">/sys/class/power_supply/battery/charging_enabled</resource>
 
 		<!-- TODO: -->
 		<resource name="camera" type="echo" />
@@ -61,41 +60,24 @@
 
 	<control name="usb">
 		<mitigation level="off"><value resource="usb">1500000</value></mitigation>
-		<mitigation level="1"><value resource="usb">1100000</value></mitigation>
-		<mitigation level="2"><value resource="usb">900000</value></mitigation>
-		<mitigation level="3"><value resource="usb">700000</value></mitigation>
-		<mitigation level="4"><value resource="usb">500000</value></mitigation>
-		<mitigation level="5"><value resource="usb">300000</value></mitigation>
-		<mitigation level="6"><value resource="usb">150000</value></mitigation>
+		<mitigation level="1"><value resource="usb">1250000</value></mitigation>
+		<mitigation level="2"><value resource="usb">1000000</value></mitigation>
+		<mitigation level="3"><value resource="usb">750000</value></mitigation>
+		<mitigation level="4"><value resource="usb">650000</value></mitigation>
 	</control>
 
-	<!--<control name="dc">
-		<mitigation level="off"><value resource="dc">1800000</value></mitigation>
-		<mitigation level="1"><value resource="dc">1100000</value></mitigation>
-		<mitigation level="2"><value resource="dc">900000</value></mitigation>
-		<mitigation level="3"><value resource="dc">700000</value></mitigation>
-		<mitigation level="4"><value resource="dc">500000</value></mitigation>
-		<mitigation level="5"><value resource="dc">300000</value></mitigation>
-		<mitigation level="6"><value resource="dc">150000</value></mitigation>
-	</control>-->
-
-	<control name="charge_en">
-		<mitigation level="off"><value resource="charge_en">1</value></mitigation>
-		<mitigation level="1"><value resource="charge_en">0</value></mitigation>
+	<control name="battery_protect">
+		<mitigation level="off"><value resource="charging_enabled">1</value></mitigation>
+		<mitigation level="1"><value resource="charging_enabled">0</value></mitigation>
 		<mitigation level="2"><value resource="shutdown" /></mitigation>
 	</control>
 
 	<control name="charging">
-		<mitigation level="off"><value resource="charger">0</value></mitigation>
-		<mitigation level="1"><value resource="charger">1</value></mitigation>
-		<mitigation level="2"><value resource="charger">2</value></mitigation>
-		<mitigation level="3"><value resource="charger">3</value></mitigation>
-		<mitigation level="4"><value resource="charger">4</value></mitigation>
-		<mitigation level="5"><value resource="charger">5</value></mitigation>
-		<mitigation level="6"><value resource="charger">6</value></mitigation>
-		<mitigation level="7"><value resource="charger">7</value></mitigation>
-		<mitigation level="8"><value resource="charger">8</value></mitigation>
-		<mitigation level="9"><value resource="charger">9</value></mitigation>
+		<mitigation level="off"><value resource="charge_speed">0</value></mitigation>
+		<mitigation level="1"><value resource="charge_speed">1</value></mitigation>
+		<mitigation level="2"><value resource="charge_speed">2</value></mitigation>
+		<mitigation level="3"><value resource="charge_speed">3</value></mitigation>
+		<mitigation level="4"><value resource="charge_speed">4</value></mitigation>
 	</control>
 
 	<control name="modem">
@@ -111,32 +93,35 @@
 
 	<control name="shutdown">
 		<mitigation level="off" />
-		<mitigation level="1"><value resource="shutdown" /></mitigation>
+		<mitigation level="1"><value resource="shutdown"/></mitigation>
 	</control>
 
 	<control name="backlight">
 		<mitigation level="off"><value resource="backlight">255</value></mitigation>
-		<mitigation level="1"><value resource="backlight">192</value></mitigation>
-		<mitigation level="2"><value resource="backlight">128</value></mitigation>
-		<mitigation level="3"><value resource="backlight">64</value></mitigation>
-		<mitigation level="4"><value resource="backlight">51</value></mitigation>
+		<mitigation level="1"><value resource="backlight">251</value></mitigation>
+		<mitigation level="2"><value resource="backlight">244</value></mitigation>
+		<mitigation level="3"><value resource="backlight">220</value></mitigation>
+		<mitigation level="4"><value resource="backlight">208</value></mitigation>
+		<mitigation level="5"><value resource="backlight">192</value></mitigation>
+		<mitigation level="6"><value resource="backlight">128</value></mitigation>
+		<mitigation level="7"><value resource="backlight">100</value></mitigation>
 	</control>
 
 	<control name="gpu">
-		<mitigation level="off"><value resource="gpu">450000000</value></mitigation>
-		<mitigation level="1"><value resource="gpu">320000000</value></mitigation>
-		<mitigation level="2"><value resource="gpu">200000000</value></mitigation>
+		<mitigation level="off"><value resource="kgsl-3d0">450000000</value></mitigation>
+		<mitigation level="1"><value resource="kgsl-3d0">320000000</value></mitigation>
+		<mitigation level="2"><value resource="kgsl-3d0">200000000</value></mitigation>
 		<mitigation level="3"><value resource="shutdown" /></mitigation>
 	</control>
 
 	<control name="cpu">
-		<mitigation level="off"><value resource="cpu">1190400</value></mitigation>
-		<mitigation level="1"><value resource="cpu">1094400</value></mitigation>
-		<mitigation level="2"><value resource="cpu">998400</value></mitigation>
-		<mitigation level="3"><value resource="cpu">787200</value></mitigation>
-		<mitigation level="4"><value resource="cpu">600000</value></mitigation>
-		<mitigation level="5"><value resource="cpu">384000</value></mitigation>
-		<mitigation level="6"><value resource="cpu">300000</value></mitigation>
+		<mitigation level="off"><value resource="cortex-a7">1190400</value></mitigation>
+		<mitigation level="1"><value resource="cortex-a7">1094400</value></mitigation>
+		<mitigation level="2"><value resource="cortex-a7">998400</value></mitigation>
+		<mitigation level="3"><value resource="cortex-a7">787200</value></mitigation>
+		<mitigation level="4"><value resource="cortex-a7">600000</value></mitigation>
+		<mitigation level="5"><value resource="cortex-a7">384000</value></mitigation>
+		<mitigation level="6"><value resource="cortex-a7">300000</value></mitigation>
 		<mitigation level="7"><value resource="shutdown" /></mitigation>
 	</control>
 
@@ -145,144 +130,151 @@
 		<threshold>
 			<mitigation name="shutdown" level="off" />
 		</threshold>
-		<threshold trigger="120" clear="115">
+		<threshold trigger="85" clear="75">
 			<mitigation name="shutdown" level="1" />
 		</threshold>
-	</configuration> -->
+	</configuration>-->
 
-	<!-- USB and DC -->
-	<configuration sensor="temp-emmc">
+	<!-- USB -->
+	<configuration sensor="pm8226_tz">
 		<threshold>
-			<!--<mitigation name="dc" level="off" />-->
 			<mitigation name="usb" level="off" />
 		</threshold>
-		<threshold trigger="38400" clear="36400">
-			<!--<mitigation name="dc" level="1" />-->
+		<threshold trigger="49000" clear="48000">
 			<mitigation name="usb" level="1" />
 		</threshold>
-		<threshold trigger="40000" clear="38000">
-			<!--<mitigation name="dc" level="2" />-->
+		<threshold trigger="50000" clear="49000">
 			<mitigation name="usb" level="2" />
 		</threshold>
-		<threshold trigger="41600" clear="39600">
-			<!--<mitigation name="dc" level="3" />-->
+		<threshold trigger="51000" clear="50000">
 			<mitigation name="usb" level="3" />
 		</threshold>
-		<threshold trigger="42400" clear="41200">
-			<!--<mitigation name="dc" level="4" />-->
+		<threshold trigger="57000" clear="56000">
 			<mitigation name="usb" level="4" />
-		</threshold>
-		<threshold trigger="43200" clear="42000">
-			<!--<mitigation name="dc" level="5" />-->
-			<mitigation name="usb" level="5" />
-		</threshold>
-		<threshold trigger="44800" clear="44000">
-			<!--<mitigation name="dc" level="6" />-->
-			<mitigation name="usb" level="6" />
 		</threshold>
 	</configuration>
 
 	<!-- charging -->
-	<configuration sensor="temp-emmc">
+	<configuration sensor="pm8226_tz">
 		<threshold>
 			<mitigation name="charging" level="off" />
 		</threshold>
-		<threshold trigger="38400" clear="37200">
+		<threshold trigger="49000" clear="48000">
 			<mitigation name="charging" level="2" />
 		</threshold>
-		<threshold trigger="40000" clear="38000">
+		<threshold trigger="50000" clear="49000">
+			<mitigation name="charging" level="3" />
+		</threshold>
+		<threshold trigger="51000" clear="50000">
 			<mitigation name="charging" level="4" />
 		</threshold>
-		<threshold trigger="41600" clear="39600">
-			<mitigation name="charging" level="6" />
-		</threshold>
-		<threshold trigger="43200" clear="42000">
-			<mitigation name="charging" level="7" />
-		</threshold>
-		<threshold trigger="44800" clear="43600">
-			<mitigation name="charging" level="8" />
-		</threshold>
 	</configuration>
-	<configuration sensor="temp-batt">
+
+	<configuration sensor="battery">
 		<threshold>
-			<mitigation name="charge_en" level="off" />
+			<mitigation name="battery_protect" level="off" />
 		</threshold>
-		<threshold trigger="464" clear="442">
-			<mitigation name="charge_en" level="1" />
+		<threshold trigger="66000" clear="60000">
+			<mitigation name="battery_protect" level="1" />
 		</threshold>
-		<threshold trigger="800" clear="780">
-			<mitigation name="charge_en" level="2" />
+		<threshold trigger="85000" clear="75000">
+			<mitigation name="battery_protect" level="2" />
 		</threshold>
 	</configuration>
 
 	<!-- GPU -->
-	<configuration sensor="temp-emmc">
+	<configuration sensor="pm8226_tz">
 		<threshold>
 			<mitigation name="gpu" level="off" />
 		</threshold>
-		<threshold trigger="46400" clear="45200">
-			<mitigation name="gpu" level="2" />
-		</threshold>
-	</configuration>
-	<configuration sensor="temp-gpu">
-		<threshold>
-			<mitigation name="gpu" level="off" />
-		</threshold>
-		<threshold trigger="100" clear="95">
-			<mitigation name="gpu" level="1" />
-		</threshold>
-		<threshold trigger="120" clear="110">
+		<threshold trigger="66000" clear="60000">
 			<mitigation name="gpu" level="2" />
 		</threshold>
 	</configuration>
 
+	<configuration sensor="temp-adreno-305">
+		<threshold>
+			<mitigation name="gpu" level="off" />
+		</threshold>
+		<threshold trigger="100" clear="95">
+			<mitigation name="gpu" level="2" />
+		</threshold>
+		<threshold trigger="120" clear="110">
+			<mitigation name="gpu" level="3" />
+		</threshold>
+	</configuration>
+
 	<!-- modem -->
-	<configuration sensor="temp-emmc">
+	<configuration sensor="pm8226_tz">
 		<threshold>
 			<mitigation name="modem" level="off" />
 		</threshold>
-		<threshold trigger="46400" clear="45200">
+		<threshold trigger="66000" clear="60000">
 			<mitigation name="modem" level="1" />
 		</threshold>
 	</configuration>
 
 	<!-- backlight -->
-	<configuration sensor="temp-emmc">
+	<configuration sensor="pm8226_tz">
 		<threshold>
 			<mitigation name="backlight" level="off" />
 		</threshold>
-		<threshold trigger="42400" clear="41200">
+		<threshold trigger="51000" clear="50000">
 			<mitigation name="backlight" level="1" />
 		</threshold>
-		<threshold trigger="44000" clear="42800">
+		<threshold trigger="53000" clear="52000">
 			<mitigation name="backlight" level="2" />
 		</threshold>
-		<threshold trigger="45600" clear="44400">
+		<threshold trigger="54000" clear="53000">
 			<mitigation name="backlight" level="3" />
 		</threshold>
-		<threshold trigger="46400" clear="45200">
+		<threshold trigger="55000" clear="54000">
 			<mitigation name="backlight" level="4" />
+		</threshold>
+		<threshold trigger="57000" clear="56000">
+			<mitigation name="backlight" level="5" />
+		</threshold>
+		<threshold trigger="58000" clear="57000">
+			<mitigation name="backlight" level="6" />
+		</threshold>
+		<threshold trigger="66000" clear="60000">
+			<mitigation name="backlight" level="7" />
 		</threshold>
 	</configuration>
 
 	<!-- CPU -->
-	<configuration sensor="temp-cpu">
+	<configuration sensor="pm8226_tz">
 		<threshold>
 			<mitigation name="cpu" level="off" />
 		</threshold>
-		<threshold trigger="80" clear="78">
+		<threshold trigger="53000" clear="52000">
+			<mitigation name="cpu" level="1" />
+		</threshold>
+		<threshold trigger="56000" clear="55000">
+			<mitigation name="cpu" level="2" />
+		</threshold>
+		<threshold trigger="58000" clear="57000">
 			<mitigation name="cpu" level="3" />
 		</threshold>
-		<threshold trigger="90" clear="85">
+		<threshold trigger="66000" clear="60000">
 			<mitigation name="cpu" level="4" />
 		</threshold>
-		<threshold trigger="95" clear="90">
+	</configuration>
+
+	<configuration sensor="temp-cortex-a7">
+		<threshold>
+			<mitigation name="cpu" level="off" />
+		</threshold>
+		<threshold trigger="90" clear="75">
+			<mitigation name="cpu" level="2" />
+		</threshold>
+		<threshold trigger="95" clear="80">
+			<mitigation name="cpu" level="3" />
+		</threshold>
+		<threshold trigger="110" clear="100">
 			<mitigation name="cpu" level="5" />
 		</threshold>
-		<threshold trigger="110" clear="95">
-			<mitigation name="cpu" level="6" />
-		</threshold>
-		<threshold trigger="120" clear="115">
+		<threshold trigger="120" clear="110">
 			<mitigation name="cpu" level="7" />
 		</threshold>
 	</configuration>


### PR DESCRIPTION
Thermanager monitors the temperature of the SoC and its environment, and
throttles the CPU, GPU, Brightness, USB, to limit the heat output
in a hot environment. However the config was trying to control the environment
temperature by monitoring the temperature of the SoC. This is wrong.

The concequence of this was CPU throttling even under light loads as the
SoC is inherently internally hot.
- SoC temperature should only be used to prevent SoC meltdown.
- Environment temperature should be used to prevent general overheating.

The config is rewritten using the actual values found in the Stock ROM.
Some parts are renamed for clarity.

Signed-off-by: Adam Farden adam@farden.cz
